### PR TITLE
Enhance chessboard layout and notations; add responsive design and up…

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -34,7 +34,7 @@ h1 {
 
 /* Chessboard container */
 #myBoard {
-  margin: 20px;
+  margin: 0px;
   width: 600px;
   border: 2px solid #ccc;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
@@ -57,6 +57,7 @@ h1 {
 /* Info box styling */
 .info-box {
   flex: 1 1 400px; /* Flexible width with a minimum size */
+  margin: 20px;
   padding: 20px;
   border: 2px solid #ddd;
   border-radius: 8px;
@@ -117,16 +118,65 @@ button:hover {
   cursor: pointer;
 }
 
+.board-wrapper {
+    position: relative; /* Ensure the wrapper is the reference point for absolute positioning */
+    width: 600px; /* Match the width of #myBoard */
+    height: 600px; /* Match the height of #myBoard */
+    margin: 0 auto; /* Center the board-wrapper */
+  }
+
+  .notation {
+    position: absolute;
+    display: flex;
+    pointer-events: none; /* Prevent notations from interfering with board interactions */
+  }
+
+  .notation-bottom {
+    bottom: -20px;
+    left: 0;
+    right: 0;
+    justify-content: space-between; /* Distribute the notations evenly */
+  }
+
+  .notation-left {
+    top: 0;
+    bottom: 0;
+    left: -12px;
+    flex-direction: column;
+    justify-content: space-between; /* Distribute the notations evenly */
+  }
+
+  .notation span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-weight: bold;
+    width: 12.5%; /* Adjust as needed to fit the board */
+  }
+
+  .notation-left span {
+    width: auto;
+    height: 12.5%; /* Adjust as needed to fit the board */
+    line-height: normal; /* Reset line-height */
+  }
+
 /* Responsive layout adjustments */
-@media (max-width: 768px) {
+@media (max-width: 1250px) {
   .game-container {
     flex-direction: column;
     align-items: center;
   }
 
+  .board-wrapper {
+    width: 90%;
+    height: 90%;
+    margin: 20px auto;
+    padding: 0px;
+}
+
   #myBoard {
-    width: 90%; /* Shrink the board for smaller screens */
-    margin: 20px auto; /* Center the chessboard */
-    display: block; /* Ensure centering */
+    width: 100%;
+    height: 100%;
   }
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,7 +8,29 @@
     <!--</div>-->
 
     <div class="game-container">
-      <div id="myBoard"></div>
+      <div class = "board-wrapper">
+        <div class="notation notation-bottom">
+          <span>A</span>
+          <span>B</span>
+          <span>C</span>
+          <span>D</span>
+          <span>E</span>
+          <span>F</span>
+          <span>G</span>
+          <span>H</span>
+        </div>
+        <div class="notation notation-left">
+          <span>8</span>
+          <span>7</span>
+          <span>6</span>
+          <span>5</span>
+          <span>4</span>
+          <span>3</span>
+          <span>2</span>
+          <span>1</span>
+        </div>
+        <div class="board" id="myBoard"></div>
+      </div>
       <div class="info-box">
         <h1>Office Chess: Welcome, {{ name }}!</h1>
         <div id="status"></div>
@@ -158,6 +180,7 @@
           }
           if (board) {
             const newOrientation = board.orientation(data.orientation)
+            updateNotations();
             moveOrientationColor = data.orientation;
           }
         });
@@ -181,6 +204,37 @@
       function resetGame() {
         window.location.href = "/reset";
       }
+
+    function updateNotations() {
+      const fileNotation = document.querySelector('.notation-bottom');
+      const rankNotation = document.querySelector('.notation-left');
+
+      if (moveOrientationColor === 'white') {
+        // White's perspective
+        const files = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+        const ranks = ['8', '7', '6', '5', '4', '3', '2', '1'];
+
+        fileNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = files[index];
+        });
+
+        rankNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = ranks[index];
+        });
+      } else {
+        // Black's perspective
+        const files = ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
+        const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
+
+        fileNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = files[index];
+        });
+
+        rankNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = ranks[index];
+        });
+      }
+    }
 
       // On page load, get initial status
       updateStatus();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,243 +1,235 @@
 {% extends 'base.html' %}
 {% block content %}
-  <div class="container">
+<div class="container">
 
     <!--<div class="info-box">-->
-    <!--  <div>FEN: <span id="fenSpan"></span></div>-->
-    <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
+        <!--  <div>FEN: <span id="fenSpan"></span></div>-->
+        <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
     <!--</div>-->
 
     <div class="game-container">
-      <div class = "board-wrapper">
-        <div class="notation notation-bottom">
-          <span>A</span>
-          <span>B</span>
-          <span>C</span>
-          <span>D</span>
-          <span>E</span>
-          <span>F</span>
-          <span>G</span>
-          <span>H</span>
+        <div class = "board-wrapper">
+            <div class="notation notation-bottom" id="notation-bottom">
+                <!-- Dynamic content will be added here -->
+            </div>
+            <div class="notation notation-left" id="notation-left">
+                <!-- Dynamic content will be added here -->
+            </div>
+            <div class="board" id="myBoard"></div>
         </div>
-        <div class="notation notation-left">
-          <span>8</span>
-          <span>7</span>
-          <span>6</span>
-          <span>5</span>
-          <span>4</span>
-          <span>3</span>
-          <span>2</span>
-          <span>1</span>
+        <div class="info-box">
+            <h1>Office Chess: Welcome, {{ name }}!</h1>
+            <div id="status"></div>
+            <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
+                <thead>
+                    <tr>
+                        <th>Move #</th>
+                        <th>White Move</th>
+                        <th>White User</th>
+                        <th>Black Move</th>
+                        <th>Black User</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Rows will be dynamically added -->
+                </tbody>
+            </table>
+            <button onclick="resetGame()">Reset Game</button>
         </div>
-        <div class="board" id="myBoard"></div>
-      </div>
-      <div class="info-box">
-        <h1>Office Chess: Welcome, {{ name }}!</h1>
-        <div id="status"></div>
-        <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
-          <thead>
-            <tr>
-              <th>Move #</th>
-              <th>White Move</th>
-              <th>White User</th>
-              <th>Black Move</th>
-              <th>Black User</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Rows will be dynamically added -->
-          </tbody>
-        </table>
-        <button onclick="resetGame()">Reset Game</button>
-      </div>
     </div>
 
     <script>
-      // Pull initial FEN from the server-side template variable
-      const initialFen = "{{ fen }}";
+        // Pull initial FEN from the server-side template variable
+        const initialFen = "{{ fen }}";
 
-      // Initialize the Chessboard2
-      const boardConfig = {
-        sparePieces: true,
-        position: initialFen,
-        draggable: true,
-        dropOffBoard: 'snapback',
-        pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
-        onDragStart,
-        onDrop
-      }
-
-      const board = Chessboard2('myBoard', boardConfig)
-
-      function isWhitePiece (piece) { return /^w/.test(piece) }
-      function isBlackPiece (piece) { return /^b/.test(piece) }
-
-      let moveOrientationColor;
-      let squareElement;
-
-      // ================================
-      //  onDragStart: highlight moves
-      // ================================
-      function onDragStart (dragData) {
-        console.log(dragData)
-        // Clear any old circles
-        board.clearCircles();
-
-        // Extract square & piece from dragData
-        let fromSquare = dragData.square;
-        let piece = dragData.piece;
-        console.log(`Dragging piece ${piece} from square ${fromSquare}`);
-
-        // only pick up pieces for the side to move
-        if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
-        if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
-
-        // If there's no valid square or piece, bail out
-        if (!fromSquare || !piece) return;
-
-        squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
-        if (squareElement) { squareElement.style.opacity = "0.5"; }
-
-        // Ask the server for all possible destination squares
-        $.post('/legal_moves', { square: fromSquare }, function(res) {
-          if (res && res.moves) {
-            console.log(`Server responded with moves:`, res.moves);
-            // Add circles for each valid destination
-            res.moves.forEach(destSquare => {
-              board.addCircle(destSquare);  // default circle
-            });
-          } else {
-            console.log('No moves returned from /legal_moves');
-          }
-        }).fail(function() {
-          console.error('Failed to retrieve legal moves from server');
-        });
-      }
-
-      // ================================
-      //  onDrop: make the move
-      // ================================
-      function onDrop (dropData) {
-        // Remove circles
-        board.clearCircles();
-
-        if (squareElement) {
-          squareElement.style.opacity = "1.0";
-          squareElement = null;
+        // Initialize the Chessboard2
+        const boardConfig = {
+            sparePieces: true,
+            position: initialFen,
+            draggable: true,
+            dropOffBoard: 'snapback',
+            pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
+            onDragStart,
+            onDrop
         }
 
-        // Build a UCI-like string, e.g. "e2e4"
-        let moveStr = dropData.source + dropData.target;
+        const board = Chessboard2('myBoard', boardConfig)
 
-        $.post('/make_move', { move: moveStr }, function(data) {
-          if (data.status === 'ok') {
-            board.position(data.fen);
+        function isWhitePiece (piece) { return /^w/.test(piece) }
+        function isBlackPiece (piece) { return /^b/.test(piece) }
+
+        let moveOrientationColor;
+        let squareElement;
+
+        // ================================
+        //  onDragStart: highlight moves
+        // ================================
+        function onDragStart (dragData) {
+            console.log(dragData)
+            // Clear any old circles
+            board.clearCircles();
+
+            // Extract square & piece from dragData
+            let fromSquare = dragData.square;
+            let piece = dragData.piece;
+            console.log(`Dragging piece ${piece} from square ${fromSquare}`);
+
+            // only pick up pieces for the side to move
+            if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
+            if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
+
+            // If there's no valid square or piece, bail out
+            if (!fromSquare || !piece) return;
+
+            squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
+            if (squareElement) { squareElement.style.opacity = "0.5"; }
+
+            // Ask the server for all possible destination squares
+            $.post('/legal_moves', { square: fromSquare }, function(res) {
+                if (res && res.moves) {
+                    console.log(`Server responded with moves:`, res.moves);
+                    // Add circles for each valid destination
+                    res.moves.forEach(destSquare => {
+                        board.addCircle(destSquare);  // default circle
+                    });
+                } else {
+                    console.log('No moves returned from /legal_moves');
+                }
+            }).fail(function() {
+                console.error('Failed to retrieve legal moves from server');
+            });
+        }
+
+        // ================================
+        //  onDrop: make the move
+        // ================================
+        function onDrop (dropData) {
+            // Remove circles
+            board.clearCircles();
+
+            if (squareElement) {
+                squareElement.style.opacity = "1.0";
+                squareElement = null;
+            }
+
+            // Build a UCI-like string, e.g. "e2e4"
+            let moveStr = dropData.source + dropData.target;
+
+            $.post('/make_move', { move: moveStr }, function(data) {
+                if (data.status === 'ok') {
+                    board.position(data.fen);
+                    updateStatus();
+                } else {
+                    // If server says illegal or error => revert
+                    document.getElementById('status').innerText = data.message;
+                }
+            }).fail(function() {
+                board.position(dropData.oldPos);
+                document.getElementById('status').innerText = "Server error, move not processed.";
+            });
+
+            return 'snapback';
+        }
+
+        // Connect to Socket.IO
+        const socket = io(location.origin, { path: '/socket.io' });
+
+        // Listen for "board_update" events from the server
+        socket.on('board_update', function(data) {
+            console.log("Received board_update from server:", data);
+            // data.fen, data.pgn, data.statusText
+            if (board) {
+                board.position(data.fen);
+            }
             updateStatus();
-          } else {
-            // If server says illegal or error => revert
-            document.getElementById('status').innerText = data.message;
-          }
-        }).fail(function() {
-          board.position(dropData.oldPos);
-          document.getElementById('status').innerText = "Server error, move not processed.";
         });
 
-        return 'snapback';
-      }
-
-      // Connect to Socket.IO
-      const socket = io(location.origin, { path: '/socket.io' });
-
-      // Listen for "board_update" events from the server
-      socket.on('board_update', function(data) {
-        console.log("Received board_update from server:", data);
-        // data.fen, data.pgn, data.statusText
-        if (board) {
-          board.position(data.fen);
-        }
-        updateStatus();
-      });
-
-      // Refresh the game status (FEN, PGN, etc.)
-      function updateStatus() {
-        $.get('/game_status', function(data) {
-          if (data) {
-            document.getElementById('status').innerText = data.statusText;
-            <!--document.getElementById('fenSpan').innerText = data.fen;-->
-            <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
-            const table = $('#pgnTable').DataTable();
-            table.clear(); // Clear existing data
-            data.moves.forEach(row => {
-              table.row.add([
-                row["Move #"],
-                row["White Move"],
-                row["White User"],
-                row["Black Move"],
-                row["Black User"]
-              ]);
+        // Refresh the game status (FEN, PGN, etc.)
+        function updateStatus() {
+            $.get('/game_status', function(data) {
+                if (data) {
+                    document.getElementById('status').innerText = data.statusText;
+                    <!--document.getElementById('fenSpan').innerText = data.fen;-->
+                    <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
+                    const table = $('#pgnTable').DataTable();
+                    table.clear(); // Clear existing data
+                    data.moves.forEach(row => {
+                        table.row.add([
+                        row["Move #"],
+                        row["White Move"],
+                        row["White User"],
+                        row["Black Move"],
+                        row["Black User"]
+                        ]);
+                    });
+                    table.draw();
+                }
+                if (board) {
+                    const newOrientation = board.orientation(data.orientation);
+                    generateNotations();
+                    moveOrientationColor = data.orientation;
+                }
             });
-            table.draw();
-          }
-          if (board) {
-            const newOrientation = board.orientation(data.orientation)
-            updateNotations();
-            moveOrientationColor = data.orientation;
-          }
-        });
-      }
+        }
 
-      $(document).ready(function() {
-        $('#pgnTable').DataTable({
-          paging: false,
-          searching: true,
-          info: false,
-          autoWidth: true,
-          columnDefs: [
-            { className: "dt-center", targets: "_all" }
-          ]
+        $(document).ready(function() {
+            $('#pgnTable').DataTable({
+                paging: false,
+                searching: true,
+                info: false,
+                autoWidth: true,
+                columnDefs: [
+                { className: "dt-center", targets: "_all" }
+                ]
+            });
+
+            updateStatus();
+            generateNotations();
         });
 
+        // Reset the board (call server /reset)
+        function resetGame() {
+            window.location.href = "/reset";
+        }
+
+        function generateNotations() {
+            const fileNotation = document.querySelector('.notation-bottom');
+            const rankNotation = document.querySelector('.notation-left');
+
+            // Clear existing notations
+            fileNotation.innerHTML = '';
+            rankNotation.innerHTML = '';
+
+            const files = moveOrientationColor === 'white' ? ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'] : ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
+            const ranks = moveOrientationColor === 'white' ? ['8', '7', '6', '5', '4', '3', '2', '1'] : ['1', '2', '3', '4', '5', '6', '7', '8'];
+
+            files.forEach(file => {
+                const span = document.createElement('span');
+                span.textContent = file;
+                fileNotation.appendChild(span);
+            });
+
+            ranks.forEach(rank => {
+                const span = document.createElement('span');
+                span.textContent = rank;
+                rankNotation.appendChild(span);
+            });
+        }
+
+        // On page load, get initial status
         updateStatus();
-      });
 
-      // Reset the board (call server /reset)
-      function resetGame() {
-        window.location.href = "/reset";
-      }
+        // Use ResizeObserver to detect changes in the size of the board-wrapper element
+        const boardWrapper = document.querySelector('.board-wrapper');
+        if (boardWrapper) {
+            const resizeObserver = new ResizeObserver(() => {
+                if (board) {
+                    board.resize();
+                }
+            });
+            resizeObserver.observe(boardWrapper);
+        }
 
-    function updateNotations() {
-      const fileNotation = document.querySelector('.notation-bottom');
-      const rankNotation = document.querySelector('.notation-left');
-
-      if (moveOrientationColor === 'white') {
-        // White's perspective
-        const files = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
-        const ranks = ['8', '7', '6', '5', '4', '3', '2', '1'];
-
-        fileNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = files[index];
-        });
-
-        rankNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = ranks[index];
-        });
-      } else {
-        // Black's perspective
-        const files = ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
-        const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
-
-        fileNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = files[index];
-        });
-
-        rankNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = ranks[index];
-        });
-      }
-    }
-
-      // On page load, get initial status
-      updateStatus();
     </script>
-  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
A wrapper container called board-wrapper was put around the board (myBoard) such that it's always hugging the board. The notational symbols are then spanned and positioned relative to that wrapper.

The updateNotations function was written to alternate the notation between white's perspective and black's perspective depending on whose move it is.

Accordingly, all of the responsive layout adjustments are now relative to the board-wrapper

Care had to be taken when writing the CSS so that the board-wrapper does not lengthen when the move table gets long.

I noticed a little bit of inconsistency when moving into the responsive layout adjustment domain. Sometimes a bit of excess whitespace will appear on the right side of the board. It appears that the myBoard element becomes wider than the board it's actually displaying. Since the board-wrapper hugs the myBoard element, this appears as whitespace and misaligned notation. The problem seems to originate from the myBoard element, and it is very intermittent. Many attempts were made to adjust the CSS to fix this.

![image](https://github.com/user-attachments/assets/a42c73f5-fe8a-437c-bd97-02d9103ba0da)
