### PR TITLE
Implement pawn promotion in move string generation

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -34,7 +34,7 @@ h1 {
 
 /* Chessboard container */
 #myBoard {
-  margin: 20px;
+  margin: 0px;
   width: 600px;
   border: 2px solid #ccc;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
@@ -57,6 +57,7 @@ h1 {
 /* Info box styling */
 .info-box {
   flex: 1 1 400px; /* Flexible width with a minimum size */
+  margin: 20px;
   padding: 20px;
   border: 2px solid #ddd;
   border-radius: 8px;
@@ -117,16 +118,65 @@ button:hover {
   cursor: pointer;
 }
 
+.board-wrapper {
+    position: relative; /* Ensure the wrapper is the reference point for absolute positioning */
+    width: 600px; /* Match the width of #myBoard */
+    height: 600px; /* Match the height of #myBoard */
+    margin: 0 auto; /* Center the board-wrapper */
+  }
+
+  .notation {
+    position: absolute;
+    display: flex;
+    pointer-events: none; /* Prevent notations from interfering with board interactions */
+  }
+
+  .notation-bottom {
+    bottom: -20px;
+    left: 0;
+    right: 0;
+    justify-content: space-between; /* Distribute the notations evenly */
+  }
+
+  .notation-left {
+    top: 0;
+    bottom: 0;
+    left: -12px;
+    flex-direction: column;
+    justify-content: space-between; /* Distribute the notations evenly */
+  }
+
+  .notation span {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    font-weight: bold;
+    width: 12.5%; /* Adjust as needed to fit the board */
+  }
+
+  .notation-left span {
+    width: auto;
+    height: 12.5%; /* Adjust as needed to fit the board */
+    line-height: normal; /* Reset line-height */
+  }
+
 /* Responsive layout adjustments */
-@media (max-width: 768px) {
+@media (max-width: 1250px) {
   .game-container {
     flex-direction: column;
     align-items: center;
   }
 
+  .board-wrapper {
+    width: 90%;
+    height: 90%;
+    margin: 20px auto;
+    padding: 0px;
+}
+
   #myBoard {
-    width: 90%; /* Shrink the board for smaller screens */
-    margin: 20px auto; /* Center the chessboard */
-    display: block; /* Ensure centering */
+    width: 100%;
+    height: 100%;
   }
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -190,7 +190,6 @@
                 { className: "dt-center", targets: "_all" }
                 ]
             });
-
             updateStatus();
         });
 
@@ -238,6 +237,5 @@
         }
 
     </script>
-</div>
 </div>
 {% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,34 +3,20 @@
 <div class="container">
 
     <!--<div class="info-box">-->
-        <!--  <div>FEN: <span id="fenSpan"></span></div>-->
-        <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
+            <!--  <div>FEN: <span id="fenSpan"></span></div>-->
+            <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
     <!--</div>-->
 
     <div class="game-container">
         <div class = "board-wrapper">
-        <div class="notation notation-bottom">
-          <span>A</span>
-          <span>B</span>
-          <span>C</span>
-          <span>D</span>
-          <span>E</span>
-          <span>F</span>
-          <span>G</span>
-          <span>H</span>
+            <div class="notation notation-bottom" id="notation-bottom">
+                <!-- Dynamic content will be added here -->
+            </div>
+            <div class="notation notation-left" id="notation-left">
+                <!-- Dynamic content will be added here -->
+            </div>
+            <div class="board" id="myBoard"></div>
         </div>
-        <div class="notation notation-left">
-          <span>8</span>
-          <span>7</span>
-          <span>6</span>
-          <span>5</span>
-          <span>4</span>
-          <span>3</span>
-          <span>2</span>
-          <span>1</span>
-        </div>
-        <div class="board" id="myBoard"></div>
-      </div>
         <div class="info-box">
             <h1>Office Chess: Welcome, {{ name }}!</h1>
             <div id="status"></div>
@@ -53,81 +39,81 @@
     </div>
 
     <script>
-        // Pull initial FEN from the server-side template variable
-        const initialFen = "{{ fen }}";
+          // Pull initial FEN from the server-side template variable
+          const initialFen = "{{ fen }}";
 
-        // Initialize the Chessboard2
-        const boardConfig = {
-            sparePieces: true,
-            position: initialFen,
-            draggable: true,
-            dropOffBoard: 'snapback',
-            pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
-            onDragStart,
-            onDrop
-        }
+          // Initialize the Chessboard2
+          const boardConfig = {
+                sparePieces: true,
+                position: initialFen,
+                draggable: true,
+                dropOffBoard: 'snapback',
+                pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
+                onDragStart,
+                onDrop
+          }
 
-        const board = Chessboard2('myBoard', boardConfig)
+          const board = Chessboard2('myBoard', boardConfig)
 
-        function isWhitePiece (piece) { return /^w/.test(piece) }
-        function isBlackPiece (piece) { return /^b/.test(piece) }
+          function isWhitePiece (piece) { return /^w/.test(piece) }
+          function isBlackPiece (piece) { return /^b/.test(piece) }
 
-        let moveOrientationColor;
-        let squareElement;
+          let moveOrientationColor;
+          let squareElement;
 
-        // ================================
-        //  onDragStart: highlight moves
-        // ================================
-        function onDragStart (dragData) {
-            console.log(dragData)
-            // Clear any old circles
-            board.clearCircles();
+          // ================================
+          //  onDragStart: highlight moves
+          // ================================
+          function onDragStart (dragData) {
+                console.log(dragData)
+                // Clear any old circles
+                board.clearCircles();
 
-            // Extract square & piece from dragData
-            let fromSquare = dragData.square;
-            let piece = dragData.piece;
-            console.log(`Dragging piece ${piece} from square ${fromSquare}`);
+                // Extract square & piece from dragData
+                let fromSquare = dragData.square;
+                let piece = dragData.piece;
+                console.log(`Dragging piece ${piece} from square ${fromSquare}`);
 
-            // only pick up pieces for the side to move
-            if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
-            if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
+                // only pick up pieces for the side to move
+                if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
+                if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
 
-            // If there's no valid square or piece, bail out
-            if (!fromSquare || !piece) return;
+                // If there's no valid square or piece, bail out
+                if (!fromSquare || !piece) return;
 
-            squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
-            if (squareElement) { squareElement.style.opacity = "0.5"; }
+                squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
+                if (squareElement) { squareElement.style.opacity = "0.5"; }
 
-            // Ask the server for all possible destination squares
-            $.post('/legal_moves', { square: fromSquare }, function(res) {
-                if (res && res.moves) {
-                    console.log(`Server responded with moves:`, res.moves);
-                    // Add circles for each valid destination
-                    res.moves.forEach(destSquare => {
-                        board.addCircle(destSquare);  // default circle
-                    });
-                } else {
-                    console.log('No moves returned from /legal_moves');
+                // Ask the server for all possible destination squares
+                $.post('/legal_moves', { square: fromSquare }, function(res) {
+                      if (res && res.moves) {
+                            console.log(`Server responded with moves:`, res.moves);
+                            // Add circles for each valid destination
+                            res.moves.forEach(destSquare => {
+                                  board.addCircle(destSquare);  // default circle
+                            });
+                      } else {
+                            console.log('No moves returned from /legal_moves');
+                      }
+                }).fail(function() {
+                      console.error('Failed to retrieve legal moves from server');
+                });
+          }
+
+          // ================================
+          //  onDrop: make the move
+          // ================================
+          function onDrop (dropData) {
+                // Remove circles
+                board.clearCircles();
+
+                if (squareElement) {
+                      squareElement.style.opacity = "1.0";
+                      squareElement = null;
                 }
-            }).fail(function() {
-                console.error('Failed to retrieve legal moves from server');
-            });
-        }
 
-        // ================================
-        //  onDrop: make the move
-        // ================================
-        function onDrop (dropData) {
-            // Remove circles
-            board.clearCircles();
-
-            if (squareElement) {
-                squareElement.style.opacity = "1.0";
-                squareElement = null;
-            }
-
-            // Build a UCI-like string, e.g. "e2e4"
-            let moveStr = dropData.source + dropData.target;
+                // Build a UCI-like string, e.g. "e2e4"
+                let moveStr = dropData.source + dropData.target;
 
             // Check for pawn promotion
             // TODO: Implement underpromotion (to rook, bishop, or knight) in the future
@@ -137,115 +123,121 @@
                 moveStr += 'q'; // Promote to queen
             }
 
-            $.post('/make_move', { move: moveStr }, function(data) {
-                if (data.status === 'ok') {
-                    board.position(data.fen);
-                    updateStatus();
-                } else {
-                    // If server says illegal or error => revert
-                    document.getElementById('status').innerText = data.message;
-                }
-            }).fail(function() {
-                board.position(dropData.oldPos);
-                document.getElementById('status').innerText = "Server error, move not processed.";
-            });
+                $.post('/make_move', { move: moveStr }, function(data) {
+                      if (data.status === 'ok') {
+                            board.position(data.fen);
+                            updateStatus();
+                      } else {
+                            // If server says illegal or error => revert
+                            document.getElementById('status').innerText = data.message;
+                      }
+                }).fail(function() {
+                      board.position(dropData.oldPos);
+                      document.getElementById('status').innerText = "Server error, move not processed.";
+                });
 
-            return 'snapback';
-        }
+                return 'snapback';
+          }
 
-        // Connect to Socket.IO
-        const socket = io(location.origin, { path: '/socket.io' });
+          // Connect to Socket.IO
+          const socket = io(location.origin, { path: '/socket.io' });
 
-        // Listen for "board_update" events from the server
-        socket.on('board_update', function(data) {
-            console.log("Received board_update from server:", data);
-            // data.fen, data.pgn, data.statusText
-            if (board) {
-                board.position(data.fen);
-            }
-            updateStatus();
-        });
-
-        // Refresh the game status (FEN, PGN, etc.)
-        function updateStatus() {
-            $.get('/game_status', function(data) {
-                if (data) {
-                    document.getElementById('status').innerText = data.statusText;
-                    <!--document.getElementById('fenSpan').innerText = data.fen;-->
-                    <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
-                    const table = $('#pgnTable').DataTable();
-                    table.clear(); // Clear existing data
-                    data.moves.forEach(row => {
-                        table.row.add([
-                        row["Move #"],
-                        row["White Move"],
-                        row["White User"],
-                        row["Black Move"],
-                        row["Black User"]
-                        ]);
-                    });
-                    table.draw();
-                }
+          // Listen for "board_update" events from the server
+          socket.on('board_update', function(data) {
+                console.log("Received board_update from server:", data);
+                // data.fen, data.pgn, data.statusText
                 if (board) {
-                    const newOrientation = board.orientation(data.orientation)
-                    updateNotations();
-                    moveOrientationColor = data.orientation;
+                      board.position(data.fen);
                 }
-            });
-        }
+                updateStatus();
+          });
 
-        $(document).ready(function() {
-            $('#pgnTable').DataTable({
-                paging: false,
-                searching: true,
-                info: false,
-                autoWidth: true,
-                columnDefs: [
-                { className: "dt-center", targets: "_all" }
-                ]
-            });
+          // Refresh the game status (FEN, PGN, etc.)
+          function updateStatus() {
+                $.get('/game_status', function(data) {
+                      if (data) {
+                            document.getElementById('status').innerText = data.statusText;
+                            <!--document.getElementById('fenSpan').innerText = data.fen;-->
+                            <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
+                            const table = $('#pgnTable').DataTable();
+                            table.clear(); // Clear existing data
+                            data.moves.forEach(row => {
+                                  table.row.add([
+                                row["Move #"],
+                                row["White Move"],
+                                row["White User"],
+                                row["Black Move"],
+                                row["Black User"]
+                                  ]);
+                            });
+                            table.draw();
+                      }
+                      if (board) {
+                            const newOrientation = board.orientation(data.orientation);
+                            generateNotations();
+                            moveOrientationColor = data.orientation;
+                      }
+                });
+          }
+
+          $(document).ready(function() {
+                $('#pgnTable').DataTable({
+                      paging: false,
+                      searching: true,
+                      info: false,
+                      autoWidth: true,
+                      columnDefs: [
+                    { className: "dt-center", targets: "_all" }
+                      ]
+                });
 
             updateStatus();
         });
 
-        // Reset the board (call server /reset)
-        function resetGame() {
-            window.location.href = "/reset";
-      }
+          // Reset the board (call server /reset)
+          function resetGame() {
+                window.location.href = "/reset";
+        }
 
-    function updateNotations() {
-      const fileNotation = document.querySelector('.notation-bottom');
-      const rankNotation = document.querySelector('.notation-left');
+        function generateNotations() {
+            const fileNotation = document.querySelector('.notation-bottom');
+            const rankNotation = document.querySelector('.notation-left');
 
-      if (moveOrientationColor === 'white') {
-        // White's perspective
-        const files = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
-        const ranks = ['8', '7', '6', '5', '4', '3', '2', '1'];
+            // Clear existing notations
+            fileNotation.innerHTML = '';
+            rankNotation.innerHTML = '';
 
-        fileNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = files[index];
-        });
+            const files = moveOrientationColor === 'white' ? ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'] : ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
+            const ranks = moveOrientationColor === 'white' ? ['8', '7', '6', '5', '4', '3', '2', '1'] : ['1', '2', '3', '4', '5', '6', '7', '8'];
 
-        rankNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = ranks[index];
-        });
-      } else {
-        // Black's perspective
-        const files = ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
-        const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
+            files.forEach(file => {
+                const span = document.createElement('span');
+                span.textContent = file;
+                fileNotation.appendChild(span);
+            });
 
-        fileNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = files[index];
-        });
-
-        rankNotation.querySelectorAll('span').forEach((span, index) => {
-          span.textContent = ranks[index];
-        });
-      }
-      }
+            ranks.forEach(rank => {
+                const span = document.createElement('span');
+                span.textContent = rank;
+                rankNotation.appendChild(span);
+            });
+        }
 
         // On page load, get initial status
         updateStatus();
+
+        // Use ResizeObserver to detect changes in the size of the board-wrapper element
+        const boardWrapper = document.querySelector('.board-wrapper');
+        if (boardWrapper) {
+            const resizeObserver = new ResizeObserver(() => {
+                if (board) {
+                    board.resize();
+                }
+            });
+            resizeObserver.observe(boardWrapper);
+        }
+
     </script>
+</div>
 </div>
 {% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -107,6 +107,15 @@
         // Build a UCI-like string, e.g. "e2e4"
         let moveStr = dropData.source + dropData.target;
 
+        // Check for pawn promotion
+        let piece = dropData.piece[1];
+          let targetRank = dropData.target[1];
+          if (piece === 'P' && targetRank === '8') {
+            moveStr += 'q'; // Promote to queen
+          } else if (piece === 'p' && targetRank === '1') {
+            moveStr += 'q'; // Promote to queen
+        }
+
         $.post('/make_move', { move: moveStr }, function(data) {
           if (data.status === 'ok') {
             board.position(data.fen);

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -8,7 +8,29 @@
     <!--</div>-->
 
     <div class="game-container">
-        <div id="myBoard"></div>
+        <div class = "board-wrapper">
+        <div class="notation notation-bottom">
+          <span>A</span>
+          <span>B</span>
+          <span>C</span>
+          <span>D</span>
+          <span>E</span>
+          <span>F</span>
+          <span>G</span>
+          <span>H</span>
+        </div>
+        <div class="notation notation-left">
+          <span>8</span>
+          <span>7</span>
+          <span>6</span>
+          <span>5</span>
+          <span>4</span>
+          <span>3</span>
+          <span>2</span>
+          <span>1</span>
+        </div>
+        <div class="board" id="myBoard"></div>
+      </div>
         <div class="info-box">
             <h1>Office Chess: Welcome, {{ name }}!</h1>
             <div id="status"></div>
@@ -166,6 +188,7 @@
                 }
                 if (board) {
                     const newOrientation = board.orientation(data.orientation)
+                    updateNotations();
                     moveOrientationColor = data.orientation;
                 }
             });
@@ -188,7 +211,38 @@
         // Reset the board (call server /reset)
         function resetGame() {
             window.location.href = "/reset";
-        }
+      }
+
+    function updateNotations() {
+      const fileNotation = document.querySelector('.notation-bottom');
+      const rankNotation = document.querySelector('.notation-left');
+
+      if (moveOrientationColor === 'white') {
+        // White's perspective
+        const files = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+        const ranks = ['8', '7', '6', '5', '4', '3', '2', '1'];
+
+        fileNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = files[index];
+        });
+
+        rankNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = ranks[index];
+        });
+      } else {
+        // Black's perspective
+        const files = ['H', 'G', 'F', 'E', 'D', 'C', 'B', 'A'];
+        const ranks = ['1', '2', '3', '4', '5', '6', '7', '8'];
+
+        fileNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = files[index];
+        });
+
+        rankNotation.querySelectorAll('span').forEach((span, index) => {
+          span.textContent = ranks[index];
+        });
+      }
+      }
 
         // On page load, get initial status
         updateStatus();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,198 +1,197 @@
 {% extends 'base.html' %}
 {% block content %}
-  <div class="container">
+<div class="container">
 
     <!--<div class="info-box">-->
-    <!--  <div>FEN: <span id="fenSpan"></span></div>-->
-    <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
+        <!--  <div>FEN: <span id="fenSpan"></span></div>-->
+        <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
     <!--</div>-->
 
     <div class="game-container">
-      <div id="myBoard"></div>
-      <div class="info-box">
-        <h1>Office Chess: Welcome, {{ name }}!</h1>
-        <div id="status"></div>
-        <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
-          <thead>
-            <tr>
-              <th>Move #</th>
-              <th>White Move</th>
-              <th>White User</th>
-              <th>Black Move</th>
-              <th>Black User</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Rows will be dynamically added -->
-          </tbody>
-        </table>
-        <button onclick="resetGame()">Reset Game</button>
-      </div>
+        <div id="myBoard"></div>
+        <div class="info-box">
+            <h1>Office Chess: Welcome, {{ name }}!</h1>
+            <div id="status"></div>
+            <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
+                <thead>
+                    <tr>
+                        <th>Move #</th>
+                        <th>White Move</th>
+                        <th>White User</th>
+                        <th>Black Move</th>
+                        <th>Black User</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Rows will be dynamically added -->
+                </tbody>
+            </table>
+            <button onclick="resetGame()">Reset Game</button>
+        </div>
     </div>
 
     <script>
-      // Pull initial FEN from the server-side template variable
-      const initialFen = "{{ fen }}";
+        // Pull initial FEN from the server-side template variable
+        const initialFen = "{{ fen }}";
 
-      // Initialize the Chessboard2
-      const boardConfig = {
-        sparePieces: true,
-        position: initialFen,
-        draggable: true,
-        dropOffBoard: 'snapback',
-        pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
-        onDragStart,
-        onDrop
-      }
+        // Initialize the Chessboard2
+        const boardConfig = {
+            sparePieces: true,
+            position: initialFen,
+            draggable: true,
+            dropOffBoard: 'snapback',
+            pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
+            onDragStart,
+            onDrop
+        }
 
-      const board = Chessboard2('myBoard', boardConfig)
+        const board = Chessboard2('myBoard', boardConfig)
 
-      function isWhitePiece (piece) { return /^w/.test(piece) }
-      function isBlackPiece (piece) { return /^b/.test(piece) }
+        function isWhitePiece (piece) { return /^w/.test(piece) }
+        function isBlackPiece (piece) { return /^b/.test(piece) }
 
-      let moveOrientationColor;
-      let squareElement;
+        let moveOrientationColor;
+        let squareElement;
 
-      // ================================
-      //  onDragStart: highlight moves
-      // ================================
-      function onDragStart (dragData) {
-        console.log(dragData)
-        // Clear any old circles
-        board.clearCircles();
+        // ================================
+        //  onDragStart: highlight moves
+        // ================================
+        function onDragStart (dragData) {
+            console.log(dragData)
+            // Clear any old circles
+            board.clearCircles();
 
-        // Extract square & piece from dragData
-        let fromSquare = dragData.square;
-        let piece = dragData.piece;
-        console.log(`Dragging piece ${piece} from square ${fromSquare}`);
+            // Extract square & piece from dragData
+            let fromSquare = dragData.square;
+            let piece = dragData.piece;
+            console.log(`Dragging piece ${piece} from square ${fromSquare}`);
 
-        // only pick up pieces for the side to move
-        if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
-        if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
+            // only pick up pieces for the side to move
+            if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
+            if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
 
-        // If there's no valid square or piece, bail out
-        if (!fromSquare || !piece) return;
+            // If there's no valid square or piece, bail out
+            if (!fromSquare || !piece) return;
 
-        squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
-        if (squareElement) { squareElement.style.opacity = "0.5"; }
+            squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
+            if (squareElement) { squareElement.style.opacity = "0.5"; }
 
-        // Ask the server for all possible destination squares
-        $.post('/legal_moves', { square: fromSquare }, function(res) {
-          if (res && res.moves) {
-            console.log(`Server responded with moves:`, res.moves);
-            // Add circles for each valid destination
-            res.moves.forEach(destSquare => {
-              board.addCircle(destSquare);  // default circle
+            // Ask the server for all possible destination squares
+            $.post('/legal_moves', { square: fromSquare }, function(res) {
+                if (res && res.moves) {
+                    console.log(`Server responded with moves:`, res.moves);
+                    // Add circles for each valid destination
+                    res.moves.forEach(destSquare => {
+                        board.addCircle(destSquare);  // default circle
+                    });
+                } else {
+                    console.log('No moves returned from /legal_moves');
+                }
+            }).fail(function() {
+                console.error('Failed to retrieve legal moves from server');
             });
-          } else {
-            console.log('No moves returned from /legal_moves');
-          }
-        }).fail(function() {
-          console.error('Failed to retrieve legal moves from server');
-        });
-      }
-
-      // ================================
-      //  onDrop: make the move
-      // ================================
-      function onDrop (dropData) {
-        // Remove circles
-        board.clearCircles();
-
-        if (squareElement) {
-          squareElement.style.opacity = "1.0";
-          squareElement = null;
         }
 
-        // Build a UCI-like string, e.g. "e2e4"
-        let moveStr = dropData.source + dropData.target;
+        // ================================
+        //  onDrop: make the move
+        // ================================
+        function onDrop (dropData) {
+            // Remove circles
+            board.clearCircles();
 
-        // Check for pawn promotion
-        let piece = dropData.piece[1];
-          let targetRank = dropData.target[1];
-          if (piece === 'P' && targetRank === '8') {
-            moveStr += 'q'; // Promote to queen
-          } else if (piece === 'p' && targetRank === '1') {
-            moveStr += 'q'; // Promote to queen
+            if (squareElement) {
+                squareElement.style.opacity = "1.0";
+                squareElement = null;
+            }
+
+            // Build a UCI-like string, e.g. "e2e4"
+            let moveStr = dropData.source + dropData.target;
+
+            // Check for pawn promotion
+            // TODO: Implement underpromotion (to rook, bishop, or knight) in the future
+            let piece = dropData.piece[1];
+            let targetRank = dropData.target[1];
+            if ((piece === 'P' && targetRank === '8') || (piece === 'P' && targetRank === '1')) {
+                moveStr += 'q'; // Promote to queen
+            }
+
+            $.post('/make_move', { move: moveStr }, function(data) {
+                if (data.status === 'ok') {
+                    board.position(data.fen);
+                    updateStatus();
+                } else {
+                    // If server says illegal or error => revert
+                    document.getElementById('status').innerText = data.message;
+                }
+            }).fail(function() {
+                board.position(dropData.oldPos);
+                document.getElementById('status').innerText = "Server error, move not processed.";
+            });
+
+            return 'snapback';
         }
 
-        $.post('/make_move', { move: moveStr }, function(data) {
-          if (data.status === 'ok') {
-            board.position(data.fen);
+        // Connect to Socket.IO
+        const socket = io(location.origin, { path: '/socket.io' });
+
+        // Listen for "board_update" events from the server
+        socket.on('board_update', function(data) {
+            console.log("Received board_update from server:", data);
+            // data.fen, data.pgn, data.statusText
+            if (board) {
+                board.position(data.fen);
+            }
             updateStatus();
-          } else {
-            // If server says illegal or error => revert
-            document.getElementById('status').innerText = data.message;
-          }
-        }).fail(function() {
-          board.position(dropData.oldPos);
-          document.getElementById('status').innerText = "Server error, move not processed.";
         });
 
-        return 'snapback';
-      }
-
-      // Connect to Socket.IO
-      const socket = io(location.origin, { path: '/socket.io' });
-
-      // Listen for "board_update" events from the server
-      socket.on('board_update', function(data) {
-        console.log("Received board_update from server:", data);
-        // data.fen, data.pgn, data.statusText
-        if (board) {
-          board.position(data.fen);
-        }
-        updateStatus();
-      });
-
-      // Refresh the game status (FEN, PGN, etc.)
-      function updateStatus() {
-        $.get('/game_status', function(data) {
-          if (data) {
-            document.getElementById('status').innerText = data.statusText;
-            <!--document.getElementById('fenSpan').innerText = data.fen;-->
-            <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
-            const table = $('#pgnTable').DataTable();
-            table.clear(); // Clear existing data
-            data.moves.forEach(row => {
-              table.row.add([
-                row["Move #"],
-                row["White Move"],
-                row["White User"],
-                row["Black Move"],
-                row["Black User"]
-              ]);
+        // Refresh the game status (FEN, PGN, etc.)
+        function updateStatus() {
+            $.get('/game_status', function(data) {
+                if (data) {
+                    document.getElementById('status').innerText = data.statusText;
+                    <!--document.getElementById('fenSpan').innerText = data.fen;-->
+                    <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
+                    const table = $('#pgnTable').DataTable();
+                    table.clear(); // Clear existing data
+                    data.moves.forEach(row => {
+                        table.row.add([
+                        row["Move #"],
+                        row["White Move"],
+                        row["White User"],
+                        row["Black Move"],
+                        row["Black User"]
+                        ]);
+                    });
+                    table.draw();
+                }
+                if (board) {
+                    const newOrientation = board.orientation(data.orientation)
+                    moveOrientationColor = data.orientation;
+                }
             });
-            table.draw();
-          }
-          if (board) {
-            const newOrientation = board.orientation(data.orientation)
-            moveOrientationColor = data.orientation;
-          }
-        });
-      }
+        }
 
-      $(document).ready(function() {
-        $('#pgnTable').DataTable({
-          paging: false,
-          searching: true,
-          info: false,
-          autoWidth: true,
-          columnDefs: [
-            { className: "dt-center", targets: "_all" }
-          ]
+        $(document).ready(function() {
+            $('#pgnTable').DataTable({
+                paging: false,
+                searching: true,
+                info: false,
+                autoWidth: true,
+                columnDefs: [
+                { className: "dt-center", targets: "_all" }
+                ]
+            });
+
+            updateStatus();
         });
 
+        // Reset the board (call server /reset)
+        function resetGame() {
+            window.location.href = "/reset";
+        }
+
+        // On page load, get initial status
         updateStatus();
-      });
-
-      // Reset the board (call server /reset)
-      function resetGame() {
-        window.location.href = "/reset";
-      }
-
-      // On page load, get initial status
-      updateStatus();
     </script>
-  </div>
+</div>
 {% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -3,8 +3,8 @@
 <div class="container">
 
     <!--<div class="info-box">-->
-            <!--  <div>FEN: <span id="fenSpan"></span></div>-->
-            <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
+        <!--  <div>FEN: <span id="fenSpan"></span></div>-->
+        <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
     <!--</div>-->
 
     <div class="game-container">
@@ -39,81 +39,81 @@
     </div>
 
     <script>
-          // Pull initial FEN from the server-side template variable
-          const initialFen = "{{ fen }}";
+        // Pull initial FEN from the server-side template variable
+        const initialFen = "{{ fen }}";
 
-          // Initialize the Chessboard2
-          const boardConfig = {
-                sparePieces: true,
-                position: initialFen,
-                draggable: true,
-                dropOffBoard: 'snapback',
-                pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
-                onDragStart,
-                onDrop
-          }
+        // Initialize the Chessboard2
+        const boardConfig = {
+            sparePieces: true,
+            position: initialFen,
+            draggable: true,
+            dropOffBoard: 'snapback',
+            pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
+            onDragStart,
+            onDrop
+        }
 
-          const board = Chessboard2('myBoard', boardConfig)
+        const board = Chessboard2('myBoard', boardConfig)
 
-          function isWhitePiece (piece) { return /^w/.test(piece) }
-          function isBlackPiece (piece) { return /^b/.test(piece) }
+        function isWhitePiece (piece) { return /^w/.test(piece) }
+        function isBlackPiece (piece) { return /^b/.test(piece) }
 
-          let moveOrientationColor;
-          let squareElement;
+        let moveOrientationColor;
+        let squareElement;
 
-          // ================================
-          //  onDragStart: highlight moves
-          // ================================
-          function onDragStart (dragData) {
-                console.log(dragData)
-                // Clear any old circles
-                board.clearCircles();
+        // ================================
+        //  onDragStart: highlight moves
+        // ================================
+        function onDragStart (dragData) {
+            console.log(dragData)
+            // Clear any old circles
+            board.clearCircles();
 
-                // Extract square & piece from dragData
-                let fromSquare = dragData.square;
-                let piece = dragData.piece;
-                console.log(`Dragging piece ${piece} from square ${fromSquare}`);
+            // Extract square & piece from dragData
+            let fromSquare = dragData.square;
+            let piece = dragData.piece;
+            console.log(`Dragging piece ${piece} from square ${fromSquare}`);
 
-                // only pick up pieces for the side to move
-                if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
-                if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
+            // only pick up pieces for the side to move
+            if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
+            if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
 
-                // If there's no valid square or piece, bail out
-                if (!fromSquare || !piece) return;
+            // If there's no valid square or piece, bail out
+            if (!fromSquare || !piece) return;
 
-                squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
-                if (squareElement) { squareElement.style.opacity = "0.5"; }
+            squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
+            if (squareElement) { squareElement.style.opacity = "0.5"; }
 
-                // Ask the server for all possible destination squares
-                $.post('/legal_moves', { square: fromSquare }, function(res) {
-                      if (res && res.moves) {
-                            console.log(`Server responded with moves:`, res.moves);
-                            // Add circles for each valid destination
-                            res.moves.forEach(destSquare => {
-                                  board.addCircle(destSquare);  // default circle
-                            });
-                      } else {
-                            console.log('No moves returned from /legal_moves');
-                      }
-                }).fail(function() {
-                      console.error('Failed to retrieve legal moves from server');
-                });
-          }
-
-          // ================================
-          //  onDrop: make the move
-          // ================================
-          function onDrop (dropData) {
-                // Remove circles
-                board.clearCircles();
-
-                if (squareElement) {
-                      squareElement.style.opacity = "1.0";
-                      squareElement = null;
+            // Ask the server for all possible destination squares
+            $.post('/legal_moves', { square: fromSquare }, function(res) {
+                if (res && res.moves) {
+                    console.log(`Server responded with moves:`, res.moves);
+                    // Add circles for each valid destination
+                    res.moves.forEach(destSquare => {
+                        board.addCircle(destSquare);  // default circle
+                    });
+                } else {
+                    console.log('No moves returned from /legal_moves');
                 }
+            }).fail(function() {
+                console.error('Failed to retrieve legal moves from server');
+            });
+        }
 
-                // Build a UCI-like string, e.g. "e2e4"
-                let moveStr = dropData.source + dropData.target;
+        // ================================
+        //  onDrop: make the move
+        // ================================
+        function onDrop (dropData) {
+            // Remove circles
+            board.clearCircles();
+
+            if (squareElement) {
+                squareElement.style.opacity = "1.0";
+                squareElement = null;
+            }
+
+            // Build a UCI-like string, e.g. "e2e4"
+            let moveStr = dropData.source + dropData.target;
 
             // Check for pawn promotion
             // TODO: Implement underpromotion (to rook, bishop, or knight) in the future
@@ -123,80 +123,80 @@
                 moveStr += 'q'; // Promote to queen
             }
 
-                $.post('/make_move', { move: moveStr }, function(data) {
-                      if (data.status === 'ok') {
-                            board.position(data.fen);
-                            updateStatus();
-                      } else {
-                            // If server says illegal or error => revert
-                            document.getElementById('status').innerText = data.message;
-                      }
-                }).fail(function() {
-                      board.position(dropData.oldPos);
-                      document.getElementById('status').innerText = "Server error, move not processed.";
-                });
-
-                return 'snapback';
-          }
-
-          // Connect to Socket.IO
-          const socket = io(location.origin, { path: '/socket.io' });
-
-          // Listen for "board_update" events from the server
-          socket.on('board_update', function(data) {
-                console.log("Received board_update from server:", data);
-                // data.fen, data.pgn, data.statusText
-                if (board) {
-                      board.position(data.fen);
+            $.post('/make_move', { move: moveStr }, function(data) {
+                if (data.status === 'ok') {
+                    board.position(data.fen);
+                    updateStatus();
+                } else {
+                    // If server says illegal or error => revert
+                    document.getElementById('status').innerText = data.message;
                 }
-                updateStatus();
-          });
+            }).fail(function() {
+                board.position(dropData.oldPos);
+                document.getElementById('status').innerText = "Server error, move not processed.";
+            });
 
-          // Refresh the game status (FEN, PGN, etc.)
-          function updateStatus() {
-                $.get('/game_status', function(data) {
-                      if (data) {
-                            document.getElementById('status').innerText = data.statusText;
-                            <!--document.getElementById('fenSpan').innerText = data.fen;-->
-                            <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
-                            const table = $('#pgnTable').DataTable();
-                            table.clear(); // Clear existing data
-                            data.moves.forEach(row => {
-                                  table.row.add([
-                                row["Move #"],
-                                row["White Move"],
-                                row["White User"],
-                                row["Black Move"],
-                                row["Black User"]
-                                  ]);
-                            });
-                            table.draw();
-                      }
-                      if (board) {
-                            const newOrientation = board.orientation(data.orientation);
-                            generateNotations();
-                            moveOrientationColor = data.orientation;
-                      }
-                });
-          }
+            return 'snapback';
+        }
 
-          $(document).ready(function() {
-                $('#pgnTable').DataTable({
-                      paging: false,
-                      searching: true,
-                      info: false,
-                      autoWidth: true,
-                      columnDefs: [
-                    { className: "dt-center", targets: "_all" }
-                      ]
-                });
+        // Connect to Socket.IO
+        const socket = io(location.origin, { path: '/socket.io' });
+
+        // Listen for "board_update" events from the server
+        socket.on('board_update', function(data) {
+            console.log("Received board_update from server:", data);
+            // data.fen, data.pgn, data.statusText
+            if (board) {
+                board.position(data.fen);
+            }
+            updateStatus();
+        });
+
+        // Refresh the game status (FEN, PGN, etc.)
+        function updateStatus() {
+            $.get('/game_status', function(data) {
+                if (data) {
+                    document.getElementById('status').innerText = data.statusText;
+                    <!--document.getElementById('fenSpan').innerText = data.fen;-->
+                    <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
+                    const table = $('#pgnTable').DataTable();
+                    table.clear(); // Clear existing data
+                    data.moves.forEach(row => {
+                        table.row.add([
+                        row["Move #"],
+                        row["White Move"],
+                        row["White User"],
+                        row["Black Move"],
+                        row["Black User"]
+                        ]);
+                    });
+                    table.draw();
+                }
+                if (board) {
+                    const newOrientation = board.orientation(data.orientation);
+                    generateNotations();
+                    moveOrientationColor = data.orientation;
+                }
+            });
+        }
+
+        $(document).ready(function() {
+            $('#pgnTable').DataTable({
+                paging: false,
+                searching: true,
+                info: false,
+                autoWidth: true,
+                columnDefs: [
+                { className: "dt-center", targets: "_all" }
+                ]
+            });
 
             updateStatus();
         });
 
-          // Reset the board (call server /reset)
-          function resetGame() {
-                window.location.href = "/reset";
+        // Reset the board (call server /reset)
+        function resetGame() {
+            window.location.href = "/reset";
         }
 
         function generateNotations() {


### PR DESCRIPTION
So it turns out that chess.pgn does actually return an array of valid moves, but the array has a bunch of duplicate elements corresponding to which piece you want to promote the pawn to. Since we have no way of specifying, it doesn't know what to do and gives an error.

For example, a white pawn on g7 can promote to g8 on the next move. The valid move array looks like ['g8', 'g8', 'g8', 'g8']. There are coincidentally 4 valid pieces you can promote to: queen, rook, bishop, knight.

To send a valid moveStr, you need to append the piece you want to promote to. So, in our example, this would be g7g8q. Sending g7g8 results in the error we observed.

A common workaround for this is to assume the user will want to promote to a queen since this is the best move 99% of the time. However, there are rare cases where it's advantageous to underpromote to a rook, knight, or bishop.

Future work would include allowing underpromotion. This would involve some kind of a selection menu for which piece the user wants to promote to, but it's not a top priority right now.