### PR TITLE
Add scrollable table for PGN moves; implement auto-scroll to bottom o…

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -81,18 +81,20 @@ table.dataTable thead th {
     text-align: center !important;
 }
 
-table.dataTable.stripe tbody tr.even, table.dataTable.display tbody tr.even {
+/* Remove background color for even rows in striped and displayed tables */
+table.dataTable.stripe tbody tr.even,
+table.dataTable.display tbody tr.even {
     background-color: transparent !important;
 }
 
 /* Custom styles for specific columns */
 .column-white {
-    background-color: #ffffff; /* White background */
+    background: #ffffff; /* White background */
     color: #000; /* Black text */
 }
 
 .column-black {
-    background-color: #4a4a4a; /* Dark grey background */
+    background: #4a4a4a; /* Dark grey background */
     color: #fff; /* White text */
 }
 

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -117,6 +117,19 @@ button:hover {
   cursor: pointer;
 }
 
+  .scrollable-table {
+    height: 400px;
+    overflow-y: auto;
+    position: relative;
+  }
+
+  .scrollable-table thead {
+    position: sticky;
+    top: 0;
+    background-color: white; /* Ensure the header has a background */
+    z-index: 1; /* Ensure the header is above the table rows */
+  }
+
 /* Responsive layout adjustments */
 @media (max-width: 768px) {
   .game-container {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -1,145 +1,143 @@
 /* General body styling */
 body {
-  margin: 0;
-  padding: 0;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  background: #f8f9fa;
-  font-family: 'Open Sans', sans-serif;
-  color: #333;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background: #f8f9fa;
+    font-family: 'Open Sans', sans-serif;
+    color: #333;
 }
 
 /* Central container for layout */
 .container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 /* Page title styling */
 h1, h2 {
-  text-align: center;
-  color: #333;
-  margin-bottom: 20px;
+    text-align: center;
+    color: #333;
+    margin-bottom: 20px;
 }
 
 h1 {
-  margin-top: 40px;
+    margin-top: 40px;
 }
 
 /* Chessboard container */
 #myBoard {
-  margin: 20px;
-  width: 600px;
-  border: 2px solid #ccc;
-  box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
+    margin: 20px;
+    width: 600px;
+    border: 2px solid #ccc;
+    box-shadow: 0 0 8px rgba(0, 0, 0, 0.1);
 }
 
 /* Game and info container layout */
 .game-container {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 20px;
-  width: 100%;
-  background: #fff;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-  border-radius: 8px;
-  padding: 20px;
-  box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 20px;
+    width: 100%;
+    background: #fff;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    padding: 20px;
+    box-sizing: border-box;
 }
 
 /* Info box styling */
 .info-box {
-  flex: 1 1 400px; /* Flexible width with a minimum size */
-  padding: 20px;
-  border: 2px solid #ddd;
-  border-radius: 8px;
-  background-color: #f9f9f9;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    flex: 1 1 400px; /* Flexible width with a minimum size */
+    padding: 20px;
+    border: 2px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    min-width: 300px; /* Ensure a minimum width */
+}
+
+:root {
+    --dt-row-stripe-alpha: 0 !important; /* Set the alpha to 0 to remove the stripe effect */
 }
 
 /* Data table styling */
 #pgnTable {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 10px;
+    width: auto; /* Let the table adjust based on its content */
+    border-collapse: collapse;
+    margin-top: 10px;
 }
 
-#pgnTable thead th {
-  background-color: #444;
-  color: #fff;
-  font-weight: bold;
-  text-align: left;
-  padding: 8px;
+/* Ensure centering for all table headers and footers */
+table.dataTable thead th {
+    text-align: center !important;
 }
 
-#pgnTable tbody td {
-  font-family: 'Courier New', Courier, monospace;
-  padding: 8px;
-  border: 1px solid #ddd;
+table.dataTable.stripe tbody tr.even, table.dataTable.display tbody tr.even {
+    background-color: transparent !important;
+}
+
+/* Custom styles for specific columns */
+.column-white {
+    background-color: #ffffff; /* White background */
+    color: #000; /* Black text */
+}
+
+.column-black {
+    background-color: #4a4a4a; /* Dark grey background */
+    color: #fff; /* White text */
 }
 
 /* Button styling */
 button {
-  display: block;
-  margin: 25px auto;
-  padding: 10px 20px;
-  background: #007bff;
-  border: none;
-  border-radius: 4px;
-  color: #fff;
-  font-size: 16px;
-  cursor: pointer;
-  transition: background 0.2s ease-in-out;
+    display: block;
+    margin: 25px auto;
+    padding: 10px 20px;
+    background: #007bff;
+    border: none;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background 0.2s ease-in-out;
 }
 
 button:hover {
-  background: #0056b3;
+    background: #0056b3;
 }
 
 /* Square coloring and hover effect */
 .white-1e1d7 {
-  background-color: #f0d9b5 !important;
+    background-color: #f0d9b5 !important;
 }
 
 .black-3c85d {
-  background-color: #b58863 !important;
+    background-color: #b58863 !important;
 }
 
 .square-55d63:hover {
-  box-shadow: inset 0 0 0 3px rgba(255, 255, 0, 0.4);
-  cursor: pointer;
+    box-shadow: inset 0 0 0 3px rgba(255, 255, 0, 0.4);
+    cursor: pointer;
 }
-
-  .scrollable-table {
-    height: 400px;
-    overflow-y: auto;
-    position: relative;
-  }
-
-  .scrollable-table thead {
-    position: sticky;
-    top: 0;
-    background-color: white; /* Ensure the header has a background */
-    z-index: 1; /* Ensure the header is above the table rows */
-  }
 
 /* Responsive layout adjustments */
 @media (max-width: 768px) {
-  .game-container {
-    flex-direction: column;
-    align-items: center;
-  }
+    .game-container {
+        flex-direction: column;
+        align-items: center;
+    }
 
-  #myBoard {
-    width: 90%; /* Shrink the board for smaller screens */
-    margin: 20px auto; /* Center the chessboard */
-    display: block; /* Ensure centering */
-  }
+    #myBoard {
+        width: 90%; /* Shrink the board for smaller screens */
+        margin: 20px auto; /* Center the chessboard */
+        display: block; /* Ensure centering */
+    }
 }

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,73 +1,103 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
+<head>
     <meta charset="UTF-8" />
     <title>Office Chess</title>
 
     <!-- Optional CSS -->
     <link
-      rel="stylesheet"
-      href="{{url_for('static', filename='styles.css')}}"
+        rel="stylesheet"
+        href="{{url_for('static', filename='styles.css')}}"
     />
 
-     <!-- Google Fonts (optional) -->
+    <!-- Google Fonts (optional) -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
-      href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap"
-      rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600&display=swap"
+        rel="stylesheet"
     >
 
     <!-- jQuery (CDN) -->
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
-      integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
+        src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js"
+        integrity="sha512-v2CJ7UaYy4JwqLDIrZUI/4hqeoQieOmAZNXBeQyjo21dadnwR+8ZaIJVT8EE2iyI61OV8e6M8PP2/4hpQINQ/g=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
     ></script>
 
     <!-- Chessboard2 CSS (CDN) -->
     <link
-      rel="stylesheet"
-      href="https://unpkg.com/@chrisoakman/chessboard2@0.5.0/dist/chessboard2.min.css"
-      integrity="sha384-47VeTDpmy4yT21gKPXQcLQYQZwlmz27gEH5NTrOmTk3G/SGvMyltclOW/Q8uE+sL"
-      crossorigin="anonymous"
+        rel="stylesheet"
+        href="https://unpkg.com/@chrisoakman/chessboard2@0.5.0/dist/chessboard2.min.css"
+        integrity="sha384-47VeTDpmy4yT21gKPXQcLQYQZwlmz27gEH5NTrOmTk3G/SGvMyltclOW/Q8uE+sL"
+        crossorigin="anonymous"
     />
 
     <!-- Chessboard2 JavaScript (CDN) -->
     <script
-      src="https://unpkg.com/@chrisoakman/chessboard2@0.5.0/dist/chessboard2.min.js"
-      integrity="sha384-/KwQCjA1GWovZNV3QDVtvSMDzO4reGgarF/RqHipr7hIUElH3r5zNl9WEPPOBRIF"
-      crossorigin="anonymous"
+        src="https://unpkg.com/@chrisoakman/chessboard2@0.5.0/dist/chessboard2.min.js"
+        integrity="sha384-/KwQCjA1GWovZNV3QDVtvSMDzO4reGgarF/RqHipr7hIUElH3r5zNl9WEPPOBRIF"
+        crossorigin="anonymous"
     ></script>
 
     <!-- DataTables CSS (CDN) -->
     <link
-      rel="stylesheet"
-      href="https://cdn.datatables.net/2.1.8/css/dataTables.dataTables.css"
-      crossorigin="anonymous"
+        rel="stylesheet"
+        href="https://cdn.datatables.net/2.2.1/css/dataTables.dataTables.min.css"
+        crossorigin="anonymous"
     />
 
     <!-- DataTables JavaScript (CDN) -->
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/datatables.net/2.1.8/dataTables.min.js"
-      integrity="sha512-aB+KD1UH6xhwz0ZLqIGK+if/B83XzgnFzDJtf195axOEqurA7ahWCpl8wgXWVfcMslhnmYigAjYXShrJSlxgWg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
+        src="https://cdn.datatables.net/2.2.1/js/dataTables.min.js"
+        integrity="sha512-j0JNzzcT4VrPZe1L2nLrJpaQqH5FHhG7dG2P+yOcIRxwm5G5NDf3em4rd3pFEfTs6ta5itVC49GE1+r7Ej/bSw=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
+
+    <!-- DataTables Scroller CSS (CDN) -->
+    <link
+        rel="stylesheet"
+        href="https://cdn.datatables.net/scroller/2.4.3/css/scroller.dataTables.min.css"
+        crossorigin="anonymous"
+    />
+
+    <!-- DataTables Scroller JavaScript (CDN) -->
+    <script
+        src="https://cdn.datatables.net/scroller/2.4.3/js/dataTables.scroller.min.js"
+        integrity="sha512-bfSzsN8iShTe3z3/mi8xNYAbFXHp43w5Fr20nnlZ3VSeoRzqHPmVjBOinP4zNWK0k5ZfQtYMdBPGVS6U9Dp0Cw=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
+
+    <!-- DataTables FixedHeader CSS (CDN) -->
+    <link
+        rel="stylesheet"
+        href="https://cdn.datatables.net/fixedheader/4.0.1/css/fixedHeader.dataTables.min.css"
+        crossorigin="anonymous"
+    />
+
+    <!-- DataTables FixedHeader JavaScript (CDN) -->
+    <script
+        src="https://cdn.datatables.net/fixedheader/4.0.1/js/dataTables.fixedHeader.min.js"
+        integrity="sha512-W5OWvAnlm06JdQj5r3JePYNJ1PSK8kHK/fgaY/WxsLyIoENmxXwWfN0DGp3UVIcnh8ucWLZNxDaS8nUrfj6vGg=="
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
     ></script>
 
     <!-- Socket.IO client library (served automatically by Flask-SocketIO): ISSUES; Hence, using CDN -->
     <!-- load a socket.io v4 client from CDN -->
     <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"
-      integrity="sha384-mkQ3/7FUtcGyoppY6bz/PORYoGqOl7/aSUMn2ymDOJcapfS6PHqxhRTMh1RR0Q6+"
-      crossorigin="anonymous"
+        src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.8.1/socket.io.min.js"
+        integrity="sha384-mkQ3/7FUtcGyoppY6bz/PORYoGqOl7/aSUMn2ymDOJcapfS6PHqxhRTMh1RR0Q6+"
+        crossorigin="anonymous"
     ></script>
 
-  </head>
+</head>
 
-  <body>
+<body>
     <div class="content">{% block content %} {% endblock %}</div>
-  </body>
+</body>
 
 </html>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -158,8 +158,11 @@
                         row["Black User"]
                         ]);
                     });
+                    var isScrolledToBottomVar = isScrolledToBottom();
                     table.draw();
-                    scrollToBottom();
+                    if (isScrolledToBottomVar){
+                        scrollToBottom();
+                    }
                 }
                 if (board) {
                     const newOrientation = board.orientation(data.orientation);
@@ -170,6 +173,12 @@
 
         $(document).ready(function() {
             $('#pgnTable').DataTable({
+                "preDrawCallback": function (settings) {
+                    pageScrollPos = $('div.dataTables_scrollBody').scrollTop();
+                },
+                "drawCallback": function (settings) {
+                    $('div.dataTables_scrollBody').scrollTop(pageScrollPos);
+                },
                 scrollY: '275px',
                 scroller: true,
                 fixedHeader: true,
@@ -191,6 +200,18 @@
         function resetGame() {
             window.location.href = "/reset";
         }
+
+        function isScrolledToBottom() {
+            const scrollBody = document.querySelector('.dt-scroll-body');
+            return scrollBody.scrollHeight - scrollBody.scrollTop === scrollBody.clientHeight;
+        }
+
+        // function isScrolledToBottom() {
+        //     var table = $('#pgnTable').DataTable();
+        //     var bottomVisibleRow = table.row(':eq(' + table.scroller.page().end + ')', {order: 'applied', search: 'applied'}).data()[0];
+        //     var rowCount = table.rows().count();
+        //     return bottomVisibleRow === rowCount;
+        // }
 
         // On page load, get initial status
         updateStatus();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -12,20 +12,22 @@
       <div class="info-box">
         <h1>Office Chess: Welcome, {{ name }}!</h1>
         <div id="status"></div>
-        <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
-          <thead>
-            <tr>
-              <th>Move #</th>
-              <th>White Move</th>
-              <th>White User</th>
-              <th>Black Move</th>
-              <th>Black User</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Rows will be dynamically added -->
-          </tbody>
-        </table>
+        <div class="scrollable-table">
+          <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
+            <thead>
+              <tr>
+                <th>Move #</th>
+                <th>White Move</th>
+                <th>White User</th>
+                <th>Black Move</th>
+                <th>Black User</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- Rows will be dynamically added -->
+            </tbody>
+          </table>
+        </div>
         <button onclick="resetGame()">Reset Game</button>
       </div>
     </div>
@@ -49,6 +51,24 @@
 
       function isWhitePiece (piece) { return /^w/.test(piece) }
       function isBlackPiece (piece) { return /^b/.test(piece) }
+
+      function checkTableState() {
+        var table = $('#pgnTable').DataTable();
+        var order = table.order(); // Get sorting order
+        var search = table.search(); // Get search term
+        var tableContainer = document.querySelector('.scrollable-table');
+        var hasScrollbar = tableContainer.scrollHeight > tableContainer.clientHeight;
+        var isScrolledToBottom = !hasScrollbar || (tableContainer.scrollTop + tableContainer.clientHeight >= tableContainer.scrollHeight);
+
+        var isDefaultState = (order[0][0] === 0 && order[0][1] === 'asc') && (search === '') && isScrolledToBottom;
+
+        return isDefaultState;
+      }
+
+      function scrollToBottom() {
+        var tableContainer = document.querySelector('.scrollable-table');
+        tableContainer.scrollTop = tableContainer.scrollHeight;
+      }
 
       let moveOrientationColor;
       let squareElement;
@@ -136,13 +156,12 @@
         updateStatus();
       });
 
-      // Refresh the game status (FEN, PGN, etc.)
       function updateStatus() {
         $.get('/game_status', function(data) {
           if (data) {
             document.getElementById('status').innerText = data.statusText;
-            <!--document.getElementById('fenSpan').innerText = data.fen;-->
-            <!--document.getElementById('pgnSpan').innerText = data.pgn;-->
+            // document.getElementById('fenSpan').innerText = data.fen;
+            // document.getElementById('pgnSpan').innerText = data.pgn;
             const table = $('#pgnTable').DataTable();
             table.clear(); // Clear existing data
             data.moves.forEach(row => {
@@ -154,10 +173,15 @@
                 row["Black User"]
               ]);
             });
+            // Check if the table is in its default state
+            var isTableInDefaultState = checkTableState();
             table.draw();
+            if (isTableInDefaultState) {
+              scrollToBottom();
+            }
           }
           if (board) {
-            const newOrientation = board.orientation(data.orientation)
+            const newOrientation = board.orientation(data.orientation);
             moveOrientationColor = data.orientation;
           }
         });

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -50,7 +50,17 @@
         function isWhitePiece (piece) { return /^w/.test(piece) }
         function isBlackPiece (piece) { return /^b/.test(piece) }
 
-        function scrollToBottom() {
+        function isTableScrolledToBottom() {
+            const scrollContainer = document.querySelector('.dt-scroll-body');
+            if (!scrollContainer) {
+                console.error('Scroll container not found');
+                return false;
+            }
+            const { scrollHeight, scrollTop, clientHeight } = scrollContainer;
+            return scrollHeight === scrollTop + clientHeight;
+        }
+
+        function scrollTableBackToBottom() {
             const dataTable = $('#pgnTable').DataTable();
             const totalRows = dataTable.rows().count();
             if (totalRows === 0) return;
@@ -158,10 +168,13 @@
                         row["Black User"]
                         ]);
                     });
-                    var isScrolledToBottomVar = isScrolledToBottom();
+                    // Check if the table was scrolled to the bottom before redrawing
+                    const tableWasScrolledToBottom = isTableScrolledToBottom();
+                    // Redraw the table
                     table.draw();
-                    if (isScrolledToBottomVar){
-                        scrollToBottom();
+                    // Scroll back to the bottom if it was previously scrolled to the bottom
+                    if (tableWasScrolledToBottom) {
+                        scrollTableBackToBottom();
                     }
                 }
                 if (board) {
@@ -200,18 +213,6 @@
         function resetGame() {
             window.location.href = "/reset";
         }
-
-        function isScrolledToBottom() {
-            const scrollBody = document.querySelector('.dt-scroll-body');
-            return scrollBody.scrollHeight - scrollBody.scrollTop === scrollBody.clientHeight;
-        }
-
-        // function isScrolledToBottom() {
-        //     var table = $('#pgnTable').DataTable();
-        //     var bottomVisibleRow = table.row(':eq(' + table.scroller.page().end + ')', {order: 'applied', search: 'applied'}).data()[0];
-        //     var rowCount = table.rows().count();
-        //     return bottomVisibleRow === rowCount;
-        // }
 
         // On page load, get initial status
         updateStatus();

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,213 +1,199 @@
 {% extends 'base.html' %}
 {% block content %}
-  <div class="container">
+<div class="container">
 
     <!--<div class="info-box">-->
-    <!--  <div>FEN: <span id="fenSpan"></span></div>-->
-    <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
+        <!--  <div>FEN: <span id="fenSpan"></span></div>-->
+        <!--  <div>PGN: <span id="pgnSpan"></span></div>-->
     <!--</div>-->
 
     <div class="game-container">
-      <div id="myBoard"></div>
-      <div class="info-box">
-        <h1>Office Chess: Welcome, {{ name }}!</h1>
-        <div id="status"></div>
-        <div class="scrollable-table">
-          <table id="pgnTable" class="display compact" cellspacing="0" width="100%">
-            <thead>
-              <tr>
-                <th>Move #</th>
-                <th>White Move</th>
-                <th>White User</th>
-                <th>Black Move</th>
-                <th>Black User</th>
-              </tr>
-            </thead>
-            <tbody>
-              <!-- Rows will be dynamically added -->
-            </tbody>
-          </table>
+        <div id="myBoard"></div>
+        <div class="info-box">
+            <h1>Office Chess: Welcome, {{ name }}!</h1>
+            <div id="status"></div>
+            <div class="scrollable-table">
+                <table id="pgnTable" class="display compact" cellspacing="0" width=100%>
+                    <thead>
+                        <tr>
+                            <th colspan="1">#</th>
+                            <th colspan="2">White</th>
+                            <th colspan="2">Black</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <!-- Rows will be dynamically added -->
+                    </tbody>
+                </table>
+            </div>
+            <button onclick="resetGame()">Reset Game</button>
         </div>
-        <button onclick="resetGame()">Reset Game</button>
-      </div>
     </div>
 
     <script>
-      // Pull initial FEN from the server-side template variable
-      const initialFen = "{{ fen }}";
+        // Pull initial FEN from the server-side template variable
+        const initialFen = "{{ fen }}";
 
-      // Initialize the Chessboard2
-      const boardConfig = {
-        sparePieces: true,
-        position: initialFen,
-        draggable: true,
-        dropOffBoard: 'snapback',
-        pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
-        onDragStart,
-        onDrop
-      }
-
-      const board = Chessboard2('myBoard', boardConfig)
-
-      function isWhitePiece (piece) { return /^w/.test(piece) }
-      function isBlackPiece (piece) { return /^b/.test(piece) }
-
-      function checkTableState() {
-        var table = $('#pgnTable').DataTable();
-        var order = table.order(); // Get sorting order
-        var search = table.search(); // Get search term
-        var tableContainer = document.querySelector('.scrollable-table');
-        var hasScrollbar = tableContainer.scrollHeight > tableContainer.clientHeight;
-        var isScrolledToBottom = !hasScrollbar || (tableContainer.scrollTop + tableContainer.clientHeight >= tableContainer.scrollHeight);
-
-        var isDefaultState = (order[0][0] === 0 && order[0][1] === 'asc') && (search === '') && isScrolledToBottom;
-
-        return isDefaultState;
-      }
-
-      function scrollToBottom() {
-        var tableContainer = document.querySelector('.scrollable-table');
-        tableContainer.scrollTop = tableContainer.scrollHeight;
-      }
-
-      let moveOrientationColor;
-      let squareElement;
-
-      // ================================
-      //  onDragStart: highlight moves
-      // ================================
-      function onDragStart (dragData) {
-        console.log(dragData)
-        // Clear any old circles
-        board.clearCircles();
-
-        // Extract square & piece from dragData
-        let fromSquare = dragData.square;
-        let piece = dragData.piece;
-        console.log(`Dragging piece ${piece} from square ${fromSquare}`);
-
-        // only pick up pieces for the side to move
-        if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
-        if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
-
-        // If there's no valid square or piece, bail out
-        if (!fromSquare || !piece) return;
-
-        squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
-        if (squareElement) { squareElement.style.opacity = "0.5"; }
-
-        // Ask the server for all possible destination squares
-        $.post('/legal_moves', { square: fromSquare }, function(res) {
-          if (res && res.moves) {
-            console.log(`Server responded with moves:`, res.moves);
-            // Add circles for each valid destination
-            res.moves.forEach(destSquare => {
-              board.addCircle(destSquare);  // default circle
-            });
-          } else {
-            console.log('No moves returned from /legal_moves');
-          }
-        }).fail(function() {
-          console.error('Failed to retrieve legal moves from server');
-        });
-      }
-
-      // ================================
-      //  onDrop: make the move
-      // ================================
-      function onDrop (dropData) {
-        // Remove circles
-        board.clearCircles();
-
-        if (squareElement) {
-          squareElement.style.opacity = "1.0";
-          squareElement = null;
+        // Initialize the Chessboard2
+        const boardConfig = {
+            sparePieces: true,
+            position: initialFen,
+            draggable: true,
+            dropOffBoard: 'snapback',
+            pieceTheme: 'static/chesspieces/wikipedia/{piece}.png',
+            onDragStart,
+            onDrop
         }
 
-        // Build a UCI-like string, e.g. "e2e4"
-        let moveStr = dropData.source + dropData.target;
+        const board = Chessboard2('myBoard', boardConfig)
 
-        $.post('/make_move', { move: moveStr }, function(data) {
-          if (data.status === 'ok') {
-            board.position(data.fen);
-            updateStatus();
-          } else {
-            // If server says illegal or error => revert
-            document.getElementById('status').innerText = data.message;
-          }
-        }).fail(function() {
-          board.position(dropData.oldPos);
-          document.getElementById('status').innerText = "Server error, move not processed.";
-        });
+        function isWhitePiece (piece) { return /^w/.test(piece) }
+        function isBlackPiece (piece) { return /^b/.test(piece) }
 
-        return 'snapback';
-      }
-
-      // Connect to Socket.IO
-      const socket = io(location.origin, { path: '/socket.io' });
-
-      // Listen for "board_update" events from the server
-      socket.on('board_update', function(data) {
-        console.log("Received board_update from server:", data);
-        // data.fen, data.pgn, data.statusText
-        if (board) {
-          board.position(data.fen);
+        function scrollToBottom() {
+            const dataTable = $('#pgnTable').DataTable();
+            const totalRows = dataTable.rows().count();
+            if (totalRows === 0) return;
+            dataTable.scroller.toPosition(totalRows - 1, false);
         }
-        updateStatus();
-      });
 
-      function updateStatus() {
-        $.get('/game_status', function(data) {
-          if (data) {
-            document.getElementById('status').innerText = data.statusText;
-            // document.getElementById('fenSpan').innerText = data.fen;
-            // document.getElementById('pgnSpan').innerText = data.pgn;
-            const table = $('#pgnTable').DataTable();
-            table.clear(); // Clear existing data
-            data.moves.forEach(row => {
-              table.row.add([
-                row["Move #"],
-                row["White Move"],
-                row["White User"],
-                row["Black Move"],
-                row["Black User"]
-              ]);
+        let moveOrientationColor;
+        let squareElement;
+
+        // ================================
+        //  onDragStart: highlight moves
+        // ================================
+        function onDragStart (dragData) {
+            console.log(dragData)
+            // Clear any old circles
+            board.clearCircles();
+
+            // Extract square & piece from dragData
+            let fromSquare = dragData.square;
+            let piece = dragData.piece;
+            console.log(`Dragging piece ${piece} from square ${fromSquare}`);
+
+            // only pick up pieces for the side to move
+            if (moveOrientationColor === 'white' && !isWhitePiece(piece)) return false
+            if (moveOrientationColor === 'black' && !isBlackPiece(piece)) return false
+
+            // If there's no valid square or piece, bail out
+            if (!fromSquare || !piece) return;
+
+            squareElement = document.querySelector(`[data-square-coord="${fromSquare}"]`);
+            if (squareElement) { squareElement.style.opacity = "0.5"; }
+
+            // Ask the server for all possible destination squares
+            $.post('/legal_moves', { square: fromSquare }, function(res) {
+                if (res && res.moves) {
+                    console.log(`Server responded with moves:`, res.moves);
+                    // Add circles for each valid destination
+                    res.moves.forEach(destSquare => {
+                        board.addCircle(destSquare);  // default circle
+                    });
+                } else {
+                    console.log('No moves returned from /legal_moves');
+                }
+            }).fail(function() {
+                console.error('Failed to retrieve legal moves from server');
             });
-            // Check if the table is in its default state
-            var isTableInDefaultState = checkTableState();
-            table.draw();
-            if (isTableInDefaultState) {
-              scrollToBottom();
+        }
+
+        // ================================
+        //  onDrop: make the move
+        // ================================
+        function onDrop (dropData) {
+            // Remove circles
+            board.clearCircles();
+
+            if (squareElement) {
+                squareElement.style.opacity = "1.0";
+                squareElement = null;
             }
-          }
-          if (board) {
-            const newOrientation = board.orientation(data.orientation);
-            moveOrientationColor = data.orientation;
-          }
-        });
-      }
 
-      $(document).ready(function() {
-        $('#pgnTable').DataTable({
-          paging: false,
-          searching: true,
-          info: false,
-          autoWidth: true,
-          columnDefs: [
-            { className: "dt-center", targets: "_all" }
-          ]
+            // Build a UCI-like string, e.g. "e2e4"
+            let moveStr = dropData.source + dropData.target;
+
+            $.post('/make_move', { move: moveStr }, function(data) {
+                if (data.status === 'ok') {
+                    board.position(data.fen);
+                    updateStatus();
+                } else {
+                    // If server says illegal or error => revert
+                    document.getElementById('status').innerText = data.message;
+                }
+            }).fail(function() {
+                board.position(dropData.oldPos);
+                document.getElementById('status').innerText = "Server error, move not processed.";
+            });
+
+            return 'snapback';
+        }
+
+        // Connect to Socket.IO
+        const socket = io(location.origin, { path: '/socket.io' });
+
+        // Listen for "board_update" events from the server
+        socket.on('board_update', function(data) {
+            console.log("Received board_update from server:", data);
+            // data.fen, data.pgn, data.statusText
+            if (board) {
+                board.position(data.fen);
+            }
+            updateStatus();
         });
 
+        function updateStatus() {
+            $.get('/game_status', function(data) {
+                if (data) {
+                    document.getElementById('status').innerText = data.statusText;
+                    const table = $('#pgnTable').DataTable();
+                    table.clear(); // Clear existing data
+                    data.moves.forEach(row => {
+                        table.row.add([
+                        row["Move #"],
+                        row["White Move"],
+                        row["White User"],
+                        row["Black Move"],
+                        row["Black User"]
+                        ]);
+                    });
+                    table.draw();
+                    scrollToBottom();
+                }
+                if (board) {
+                    const newOrientation = board.orientation(data.orientation);
+                    moveOrientationColor = data.orientation;
+                }
+            });
+        }
+
+        $(document).ready(function() {
+            $('#pgnTable').DataTable({
+                scrollY: '275px',
+                scroller: true,
+                fixedHeader: true,
+                searching: false,
+                ordering: false,
+                info: false,
+                autoWidth: true,
+                columnDefs: [
+                { className: "dt-center", targets: "_all" },
+                { className: "column-white", targets: [1, 2] }, // Apply to White columns
+                { className: "column-black", targets: [3, 4] }  // Apply to Black columns
+                ]
+            });
+
+            updateStatus();
+        });
+
+        // Reset the board (call server /reset)
+        function resetGame() {
+            window.location.href = "/reset";
+        }
+
+        // On page load, get initial status
         updateStatus();
-      });
-
-      // Reset the board (call server /reset)
-      function resetGame() {
-        window.location.href = "/reset";
-      }
-
-      // On page load, get initial status
-      updateStatus();
     </script>
-  </div>
+</div>
 {% endblock %}

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -186,10 +186,10 @@
 
         $(document).ready(function() {
             $('#pgnTable').DataTable({
-                "preDrawCallback": function (settings) {
+                "preDrawCallback": (settings) => {
                     pageScrollPos = $('div.dataTables_scrollBody').scrollTop();
                 },
-                "drawCallback": function (settings) {
+                "drawCallback": (settings) => {
                     $('div.dataTables_scrollBody').scrollTop(pageScrollPos);
                 },
                 scrollY: '275px',


### PR DESCRIPTION
Table was made to be scrollable when it gets too long

header is floating and stays glued to the top of the table even when scrolled

There is a check to see if the table is still in its default state: no active search, scrolled to the bottom, default table sorting.

If the table is in its default state, the table will automatically bottom itself out on a new move

If the table is not in its default state (ie the user is observing something in the table) the table will retain its current state and update silently without bothering the user.